### PR TITLE
spctl failed when disabled as it exits 1

### DIFF
--- a/pyfacts
+++ b/pyfacts
@@ -390,8 +390,9 @@ class Facts(object):
 
     def get_gatekeeperstatus(self):
         '''Returns whether gatekeeper is enabled'''
-        output = subprocess.check_output(['/usr/sbin/spctl', '--status'])
-        return output.strip()
+        proc = subprocess.Popen(['/usr/sbin/spctl', '--status'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        return stdout.strip()
 
     def get_activenetwork(self):
         '''Returns the active network interface of the Mac'''


### PR DESCRIPTION
spctl's exit status is 1 when it is disabled.

This threw the following traceback:

```
ryan@AIR-ML-RMANLY pyfacts $ ./pyfacts
Traceback (most recent call last):
  File "./pyfacts", line 624, in <module>
    main()
  File "./pyfacts", line 619, in main
    d[i] = getattr(facts, 'get_' + i)()
  File "./pyfacts", line 393, in get_gatekeeperstatus
    output = subprocess.check_output(['/usr/sbin/spctl', '--status'])
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['/usr/sbin/spctl', '--status']' returned non-zero exit status 1
```

I verified that when disabled spctl exits 1 on 10.9, 10.10, and 10.11DP1.

These code changes handle that by using .Popen and .communicate.
