### PR TITLE
os.environ fix

### DIFF
--- a/pyfacts
+++ b/pyfacts
@@ -155,7 +155,11 @@ class Facts(object):
 
     def get_prompt(self):
         '''Returns the prompt env of the current user'''
-        return os.environ['PROMPT_COMMAND']
+        try:
+            pc = os.environ['PROMPT_COMMAND']
+        except KeyError:
+            pc = None
+        return pc
 
     def get_path(self):
         '''Returns the path env of the current user'''
@@ -167,7 +171,11 @@ class Facts(object):
 
     def get_termprogram(self):
         '''Returns the term program env of the current user'''
-        return os.environ['TERM_PROGRAM']
+        try:
+            tp = os.environ['TERM_PROGRAM']
+        except KeyError:
+            tp = None
+        return tp
 
     def get_shell(self):
         '''Returns the shell env of the current user'''
@@ -179,15 +187,27 @@ class Facts(object):
 
     def get_editor(self):
         '''Returns the editor env of the current user'''
-        return os.environ['EDITOR']
+        try:
+            ed = os.environ['EDITOR']
+        except KeyError:
+            ed = None
+        return ed
 
     def get_pwd(self):
         '''Returns the pwd'''
-        return os.environ['PWD']
+        try:
+            pwd = os.environ['PWD']
+        except KeyError:
+            pwd = None
+        return pwd
 
     def get_tmpdir(self):
         '''Returns the tempdir env of the current user'''
-        return os.environ['TMPDIR']
+        try:
+            td = os.environ['TMPDIR']
+        except KeyError:
+            td = None
+        return td
 
     def get_cwd(self):
         '''Returns the cwd'''

--- a/pyfacts
+++ b/pyfacts
@@ -390,8 +390,9 @@ class Facts(object):
 
     def get_gatekeeperstatus(self):
         '''Returns whether gatekeeper is enabled'''
-        output = subprocess.check_output(['/usr/sbin/spctl', '--status'])
-        return output.strip()
+        proc = subprocess.Popen(['/usr/sbin/spctl', '--status'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = proc.communicate()
+        return stdout.strip()
 
     def get_activenetwork(self):
         '''Returns the active network interface of the Mac'''


### PR DESCRIPTION
KeyErrors were not being caught when certain info. was not set in the environment. In the case of `sudo` vs. `sudo -s` or even EDITOR not being set on a fresh machine (at least in 10.11DP1).

```
ryan@AIR-ML-RMANLY pyfacts $ sudo ./pyfacts
Traceback (most recent call last):
  File "./pyfacts", line 625, in <module>
    main()
  File "./pyfacts", line 620, in main
    d[i] = getattr(facts, 'get_' + i)()
  File "./pyfacts", line 158, in get_prompt
    return os.environ['PROMPT_COMMAND']
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'PROMPT_COMMAND'

ryan@AIR-ML-RMANLY pyfacts $ sudo -s
AIR-ML-RMANLY pyfacts # ./pyfacts
Traceback (most recent call last):
  File "./pyfacts", line 625, in <module>
    main()
  File "./pyfacts", line 620, in main
    d[i] = getattr(facts, 'get_' + i)()
  File "./pyfacts", line 170, in get_termprogram
    return os.environ['TERM_PROGRAM']
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/UserDict.py", line 23, in __getitem__
    raise KeyError(key)
KeyError: 'TERM_PROGRAM'
```

These updates catch the KeyErrors on the things that are likely to be unset and return None.
